### PR TITLE
Update Readme guideline as the repo name is 'graph-untangler-plugin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 # Integration
 1. Add plugin to the root `build.gradle`
-
 ```
 // build.gradle
 plugins {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin is unpublished but can be added to projects using `includeBuild`
 1. Checkout this repository
 2. Add to `settings.gradle`
 ```
-includeBuild("/path/to/gradle-graph-untangler")
+includeBuild("/path/to/graph-untangler-plugin")
 ```
 
 3. Add plugin to root `build.gradle`


### PR DESCRIPTION
Hey, whilst trying out the plugin, first quick things was that GitHub Desktop and possibly some other tools by default checks out the project into the same directory as the repo name.

Therefore this mini edit to match the Readme with the repo name :) 

_More feedback possibly coming later once i get to try the plugin a bit more._